### PR TITLE
In dev, use package.json version instead of v0.0.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,9 +15,9 @@ Setup config.  npm-internal uses Env vars for all its config. See [usage.md](usa
 ```
 > npm-internal publish
 
-npm-package-0.0.0.tgz
+npm-package-1.0.0.tgz
 Uploading Package to S3
-package url: https://{BUCKET}.s3.amazonaws.com/package/npm-package-0.0.0-e84b5cf2ebc818b602885a9e0d7b351b8a9928d1.tgz
+package url: https://{BUCKET}.s3.amazonaws.com/package/npm-package-1.0.0-e84b5cf2ebc818b602885a9e0d7b351b8a9928d1.tgz
 ```
 
 ### dev releases
@@ -27,10 +27,10 @@ sometimes dev packages are useful for staging deploys
 ```
 > npm-internal publish --dev
 
-dev publish: npm-package-v0.0.0-2-g30bc1a6
-npm-package-0.0.0.tgz
+dev publish: npm-package-v1.0.0-2-g30bc1a6
+npm-package-1.0.0.tgz
 Uploading Package to S3
-package url: https://{BUCKET}.s3.amazonaws.com/package/npm-package-v0.0.0-2-g30bc1a6-e84b5cf2ebc818b602885a9e0d7b351b8a9928d1.tgz
+package url: https://{BUCKET}.s3.amazonaws.com/package/npm-package-v1.0.0-2-g30bc1a6-e84b5cf2ebc818b602885a9e0d7b351b8a9928d1.tgz
 ```
 
 ### show versions

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function packAndDeploy(s3, bucket, path, force, callback){
     if(argv.dev) {
         if (fs.existsSync(path+'/.git')) {
             describe = exec("git describe --tags", {cwd: path}).stdout.replace('\n', '');
-            describe = describe || 'v0.0.0-' + exec('git rev-parse head', {cwd: path}).stdout.replace('\n', '');
+            describe = describe || 'v' + npmPackage.version + '-' + exec('git rev-parse HEAD', {cwd: path}).stdout.replace('\n', '');
             console.log('dev publish: '+ npmPackage.name+'-'+describe)
         } else {
             return callback(new Error('to use --dev this has to be a git repo'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-internal",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Publish npm modules to a private s3 bucket.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
When publishing a package via `--dev` on a repo that doesn't have tags, instead of using the confusing `v0.0.0` we should use the package.json version.

/cc @mick @tmcw