### PR TITLE
Enable scoped packages

### DIFF
--- a/test/fixtures/npm-internal-scoped/index.js
+++ b/test/fixtures/npm-internal-scoped/index.js
@@ -1,0 +1,1 @@
+module.exports = function(){}

--- a/test/fixtures/npm-internal-scoped/package.json
+++ b/test/fixtures/npm-internal-scoped/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@org/npm-internal-scoped",
+  "version": "1.0.0",
+  "description": "Test a scoped package.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node test/test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/mapbox/npm-internal-scoped.git"
+  },
+  "author": "tlee@mapbox.com",
+  "license": "MIT",
+  "homepage": "https://google.com/non-existent-project",
+  "dependencies": {
+    "async": "^0.9.0"
+  }
+}


### PR DESCRIPTION
Resolves #29 

npm pack turns a scoped package into a packed name like `scope-module-1.0.0.tgz` instead of `@scope/module-1.0.0.tgz`, so this prepares the base name (i.e. `scope-module-1.0.0` to be effectively used by s3.putObject.

cc @rclark 